### PR TITLE
CHANGE(blob_indexer): Ensure service is started or restarted at the e…

### DIFF
--- a/docker-tests/test.yml
+++ b/docker-tests/test.yml
@@ -4,18 +4,17 @@
   become: true
   vars:
     NS: TRAVIS
+    openio_bootstrap: true
   roles:
     - role: users
     - role: repo
+      openio_repository_mirror_host: mirror2.openio.io
       openio_repository_no_log: false
-      openio_repository_products:
-        sds:
-          release: "18.10"
-    - role: namespace
-      openio_namespace_name: "{{ NS }}"
     - role: gridinit
       openio_gridinit_namespace: "{{ NS }}"
       openio_gridinit_per_ns: true
+    - role: namespace
+      openio_namespace_name: "{{ NS }}"
     - role: role_under_test
       openio_blob_indexer_namespace: "{{ NS }}"
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,12 +46,25 @@
         {{ openio_blob_indexer_servicename }}.conf"
   register: _blob_indexer_conf
 
-- name: restart blob_indexer
+- name: "restart blob_indexer to apply the new configuration"
   shell: |
     gridinit_cmd reload
     gridinit_cmd restart  {{ openio_blob_indexer_namespace }}-{{ openio_blob_indexer_servicename }}
+  register: _restart_blob_indexer
   when:
-    - _blob_indexer_conf.changed
+    - _blob_indexer_conf is changed
     - not openio_blob_indexer_provision_only
   tags: configure
+
+- block:
+    - name: "Ensure blob_indexer is started"
+      command: gridinit_cmd start {{ openio_blob_indexer_namespace }}-{{ openio_blob_indexer_servicename }}
+      register: _start_blob_indexer
+      changed_when: '"Success" in _start_blob_indexer.stdout'
+      when:
+        - not openio_blob_indexer_provision_only
+        - _restart_blob_indexer is skipped
+      tags: configure
+  when: openio_bootstrap | d(false)
+
 ...


### PR DESCRIPTION
…nd of role

 ##### SUMMARY
Until 18.10, a voluntarily stopped service was not revived by a reproviosionning.

In 19.04, the `maintenance` mode becomes the default mode.

To avoid having to force (ie. deletion of conf files) the restart of a service delivered first, by error, in maintenance mode: We have to make sure that service is started and it works well at the end of the role.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION