### PR TITLE
CHANGE(oio-blob-indexer): Add flag to force package upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ An Ansible role for OpenIO oio-blob-indexer. Specifically, the responsibilities 
 | `openio_blob_indexer_interval` | `300` | Secondes between 2 passes |
 | `openio_blob_indexer_namespace` | `"OPENIO"` | Namespace |
 | `openio_blob_indexer_provision_only` | `false` | Provision only without restarting services |
+| `openio_blob_indexer_package_upgrade` | `false` | Set the packages to the latest version (to be set in extra_vars) |
 | `openio_blob_indexer_report_interval` | `5` | Secondes to display progression |
 | `openio_blob_indexer_serviceid` | `"0"` | ID in gridinit |
 | `openio_blob_indexer_volume` | `"/var/lib/oio/sds/{{ openio_blob_indexer_namespace }}/oio-blob-indexer-{{ openio_blob_indexer_serviceid }}"` | Volume to index |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,4 +12,5 @@ openio_blob_indexer_interval: 300
 
 openio_blob_indexer_volume: "/var/lib/oio/sds/{{ openio_blob_indexer_namespace }}/{{ openio_blob_indexer_servicename }}"
 openio_blob_indexer_provision_only: false
+openio_blob_indexer_package_upgrade: "{{ openio_package_upgrade | d(false) }}"
 ...

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -2,7 +2,7 @@
 - name: Install packages
   package:
     name: "{{ pkg }}"
-    state: present
+    state: "{{ 'latest' if openio_blob_indexer_package_upgrade else 'present' }}"
   with_items: "{{ blob_indexer_packages }}"
   loop_control:
     loop_var: pkg

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -2,7 +2,7 @@
 - name: Install packages
   package:
     name: "{{ pkg }}"
-    state: present
+    state: "{{ 'latest' if openio_blob_indexer_package_upgrade else 'present' }}"
   with_items: "{{ blob_indexer_packages }}"
   loop_control:
     loop_var: pkg


### PR DESCRIPTION
 ##### SUMMARY

This is useful during upgrades, as it allows to update packages to the
latest version without requiring an external playbook/task.

To use this, simply provide the -e openio_package_upgrade=true argument

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION