### PR TITLE
CHANGE(oio-blob-indexer): Change default of `gridinit_dir`, `gridinit_file_…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,15 +2,15 @@
 openio_blob_indexer_namespace: "{{ namespace | default('OPENIO') }}"
 openio_blob_indexer_serviceid: "{{ 0 + openio_legacy_serviceid | d(0) | int }}"
 
-openio_blob_indexer_gridinit_dir: "/etc/gridinit.d/{{ openio_blob_indexer_namespace }}"
-openio_blob_indexer_gridinit_file_prefix: ""
+openio_blob_indexer_gridinit_dir: "{{ openio_gridinit_d | d('/etc/gridinit.d/') }}"
+openio_blob_indexer_gridinit_file_prefix: "{{ openio_blob_indexer_namespace }}-"
 
 openio_blob_indexer_report_interval: 5
 openio_blob_indexer_chunks_per_second: 2
 openio_blob_indexer_interval: 300
 
 openio_blob_indexer_volume: "/var/lib/oio/sds/{{ openio_blob_indexer_namespace }}/{{ openio_blob_indexer_servicename }}"
-openio_blob_indexer_provision_only: false
+openio_blob_indexer_provision_only: "{{ openio_maintenance_mode | d(false) | bool }}"
 openio_blob_indexer_package_upgrade: "{{ openio_package_upgrade | d(false) }}"
 
 openio_blob_indexer_state: present

--- a/docker-tests/checks.bats
+++ b/docker-tests/checks.bats
@@ -10,11 +10,11 @@
     echo "status: "$status
     [[ "${status}" -eq "0" ]]
 
-    run bash -c "docker exec -ti ${SUT_ID} stat /etc/gridinit.d/TRAVIS/oio-blob-indexer-5.conf"
+    run bash -c "docker exec -ti ${SUT_ID} stat /etc/gridinit.d/TRAVIS-oio-blob-indexer-5.conf"
     echo "status: "$status
     [[ "${status}" -eq "0" ]]
 
-    run bash -c "docker exec -ti ${SUT_ID} stat /etc/gridinit.d/TRAVIS/oio-blob-indexer-3.conf"
+    run bash -c "docker exec -ti ${SUT_ID} stat /etc/gridinit.d/TRAVIS-oio-blob-indexer-3.conf"
     echo "status: "$status
     [[ "${status}" -eq "0" ]]
 

--- a/docker-tests/test_instances.yml
+++ b/docker-tests/test_instances.yml
@@ -12,7 +12,7 @@
       openio_repository_no_log: false
     - role: gridinit
       openio_gridinit_namespace: "{{ NS }}"
-      openio_gridinit_per_ns: true
+      #openio_gridinit_per_ns: true
     - role: namespace
       openio_namespace_name: "{{ NS }}"
     - role: rawx

--- a/docker-tests/test_mono.yml
+++ b/docker-tests/test_mono.yml
@@ -12,7 +12,7 @@
       openio_repository_no_log: false
     - role: gridinit
       openio_gridinit_namespace: "{{ NS }}"
-      openio_gridinit_per_ns: true
+      #openio_gridinit_per_ns: true
     - role: namespace
       openio_namespace_name: "{{ NS }}"
     - role: rawx

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   company: OpenIO
   license: AGPLv3
 
-  min_ansible_version: 2.4
+  min_ansible_version: 2.9
 
   platforms:
     - name: Ubuntu

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,17 +29,6 @@
     - install
     - configure
 
-- name: Ensure namespace directories exist
-  file:
-    path: "{{ item }}"
-    state: directory
-    owner: openio
-    group: openio
-    mode: "0755"
-  with_items:
-    - "/etc/gridinit.d/{{ openio_blob_indexer_namespace }}"
-  tags: configure
-
 - name: "Include tasks for blob_indexer state"
   include_tasks: "{{ bi.ansible_facts._blob_indexer.state }}.yml"
   tags:


### PR DESCRIPTION
…prefix` and `provision_only`

 ##### SUMMARY

The playbook hardcode these calls. Now the defaults are good and there is no more hardcode.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION